### PR TITLE
Releasing 0.4.1 and fine tuing the .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -33,3 +33,11 @@ tsconfig.json
 CHANGELOG.md
 
 **/*/api/typings/auto-generated
+
+.changeset/
+.github/
+.husky/
+
+.eslintignore
+.nvmrc
+.prettierrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @egym/mwa-utils
 
+## 0.4.1
+
+### Patch Changes
+
+- Releasing the 0.4.x version
+
 ## 0.4.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/lib/index.js",
   "module": "./dist/es/index.js",


### PR DESCRIPTION
Bumping the patch version since version 0.4.0 was already published to npmjs registry. Also refining what files should be included in to the package.