### PR TITLE
WPE2-1261 Added feature param to trackEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @egym/mwa-utils
 
+## 0.7.2
+
+### Patch Changes
+
+- Added the optional param `feature` to `trackEvent` command 
+
 ## 0.7.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The following functions are available to send commands to the BMA:
     * `endFlowUrlPatterns` is an optional array of strings that will be used to close the webview when a url matches any of the patterns.
 1. `publishOpenUrlExternally(url: string)` publishes the `openUrlExternally` command to the BMA.
     * `url` is the url to open in the external web view.
-1. `publishTrackEvent(eventName: string, parameters?: { [key: string]: string })` publishes the `trackEvent` command to the BMA.
+1. `publishTrackEvent(eventName: string, feature?: string, parameters?: { [key: string]: string })` publishes the `trackEvent` command to the BMA.
     * `eventName` is the name of the event to track.
+    * `feature` is an optional string that represents the feature where the event is tracked. Use this if you want to use Segment to track the event.
     * `parameters` is an optional object with key-value pairs to pass to the event.
 
 ### MWA Subscriptions

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following functions are available to send commands to the BMA:
     * `url` is the url to open in the external web view.
 1. `publishTrackEvent(eventName: string, feature?: string, parameters?: { [key: string]: string })` publishes the `trackEvent` command to the BMA.
     * `eventName` is the name of the event to track.
-    * `feature` is an optional string that represents the feature where the event is tracked. Use this if you want to use Segment to track the event.
+    * `feature` is an optional string parameter represents the feature where the event is tracked. If not specified, Firebase Analytics tracking will be used by default. If specified, the event will be tracked using a custom Backend or Segment analytics, depending on whether Segment settings are enabled for the brand.
     * `parameters` is an optional object with key-value pairs to pass to the event.
 
 ### MWA Subscriptions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egym/mwa-utils",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "@modern-js/eslint-config": "2.48.2",
         "@modern-js/module-tools": "^2.48.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egym/mwa-utils",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@modern-js/eslint-config": "2.48.2",
         "@modern-js/module-tools": "^2.48.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/lib/index.js",
   "module": "./dist/es/index.js",

--- a/src/egym/mwa-commands.ts
+++ b/src/egym/mwa-commands.ts
@@ -70,11 +70,12 @@ export const publishOpenUrlExternally = (url: string) => {
 
 export const publishTrackEvent = (
   eventName: string,
+  feature?: string,
   parameters?: { [key: string]: string },
 ) => {
   return publishCommand('subscription', {
     type: 'trackEvent',
-    data: { name: eventName, parameters },
+    data: { name: eventName, feature, parameters },
   });
 };
 

--- a/tests/egym/mwa-commands.test.ts
+++ b/tests/egym/mwa-commands.test.ts
@@ -247,6 +247,7 @@ describe('useMwaPortalCommands test cases', () => {
         type: 'trackEvent',
         data: {
           name: 'event-name',
+          feature: 'feature',
           parameters: {
             paramA: 'valueA',
             'other-param': 'otherValue',
@@ -258,7 +259,7 @@ describe('useMwaPortalCommands test cases', () => {
     publish.mockImplementationOnce(() => Promise.resolve());
 
     // Act
-    const trackEventResult = await publishTrackEvent('event-name', {
+    const trackEventResult = await publishTrackEvent('event-name', 'feature', {
       paramA: 'valueA',
       'other-param': 'otherValue',
     });

--- a/tests/egym/mwa-commands.test.ts
+++ b/tests/egym/mwa-commands.test.ts
@@ -270,7 +270,37 @@ describe('useMwaPortalCommands test cases', () => {
     expect(publish.mock.calls[0][0]).toEqual(expectedCommand);
   });
 
-  test('Publish trackEvent command without parameters', async () => {
+  test('Publish trackEvent command without feature', async () => {
+    // Setup
+    const expectedCommand: PortalMessage<MwaPortalCommandsData> = {
+      topic: 'subscription',
+      data: {
+        type: 'trackEvent',
+        data: {
+          name: 'event-name',
+          parameters: {
+            paramA: 'valueA',
+            'other-param': 'otherValue',
+          },
+        },
+      },
+    };
+    const { publish } = jest.requireMock('@ionic/portals');
+    publish.mockImplementationOnce(() => Promise.resolve());
+
+    // Act
+    const trackEventResult = await publishTrackEvent('event-name', undefined, {
+      paramA: 'valueA',
+      'other-param': 'otherValue',
+    });
+
+    // Verify
+    expect(trackEventResult).toBeUndefined();
+    expect(publish).toBeCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toEqual(expectedCommand);
+  });
+
+  test('Publish trackEvent command without feature and parameters', async () => {
     // Setup
     const expectedCommand: PortalMessage<MwaPortalCommandsData> = {
       topic: 'subscription',


### PR DESCRIPTION
As agreed, added `feature` as an optional parameter to the `trackEvent` command. If this param is passed, then native should use Segment to track the event.


### New Feature Addition:

* [`src/egym/mwa-commands.ts`](diffhunk://#diff-7d61f9200c352472f5d0190377e7fdadb1a3ebca521b66d6a3f4f0f122c5af20R73-R78): Added an optional `feature` parameter to the `publishTrackEvent` function and included it in the command data.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R34): Updated the description of the `publishTrackEvent` function to include the new `feature` parameter and its purpose.

### Versioning:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.7.1` to `0.7.2` to reflect the new changes.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8): Added an entry for version `0.7.2`, describing the addition of the `feature` parameter to the `trackEvent` command.

### Tests:

* [`tests/egym/mwa-commands.test.ts`](diffhunk://#diff-f88199e6a141ca4825cbea05018ddb35890031e74e119eb643ed71eef2c8041fR250): Updated tests to include scenarios with and without the `feature` parameter for the `publishTrackEvent` function. [[1]](diffhunk://#diff-f88199e6a141ca4825cbea05018ddb35890031e74e119eb643ed71eef2c8041fR250) [[2]](diffhunk://#diff-f88199e6a141ca4825cbea05018ddb35890031e74e119eb643ed71eef2c8041fL261-R262) [[3]](diffhunk://#diff-f88199e6a141ca4825cbea05018ddb35890031e74e119eb643ed71eef2c8041fL272-R303)


https://egym.atlassian.net/browse/WPE2-1261