### PR TITLE
Relax mwa-logger peer dependency range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @egym/mwa-utils
 
+## 0.7.14
+
+### Patch Changes
+
+- Relax the `@egym/mwa-logger` peer dependency range to allow the published 0.3.x releases.
+
 ## 0.7.13
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.7.6",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egym/mwa-utils",
-      "version": "0.7.6",
+      "version": "0.7.14",
       "devDependencies": {
         "@modern-js/eslint-config": "2.48.2",
         "@modern-js/module-tools": "^2.48.2",
@@ -22,7 +22,7 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=4.1.0 <8.0.0",
-        "@egym/mwa-logger": "^0.2.8",
+        "@egym/mwa-logger": ">=0.2.8 <0.4.0",
         "@ionic/portals": ">=0.9.0 <0.13.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egym/mwa-utils",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/lib/index.js",
   "module": "./dist/es/index.js",
@@ -31,7 +31,7 @@
   ],
   "peerDependencies": {
     "@capacitor/core": ">=4.1.0 <8.0.0",
-    "@egym/mwa-logger": "^0.2.8",
+    "@egym/mwa-logger": ">=0.2.8 <0.4.0",
     "@ionic/portals": ">=0.9.0 <0.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- relax the `@egym/mwa-logger` peer dependency range to allow the published `0.3.x` releases
- bump `@egym/mwa-utils` to `0.7.14` and update the changelog for the patch release

## Validation
- `npm run change`
- `npm run bump`
- `npm run build`