### PR TITLE
chore(dependabot): only open PRs that fix security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions 
+    open-pull-requests-limit: 0
     directory: "/" 
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What
Set `open-pull-requests-limit: 0` on the package-manager & `github-actions` ecosystems in `.github/dependabot.yml` so Dependabot **only opens PRs that fix an open security alert** for them.

## Why
Routine version-update PRs (e.g. type-only/transitive bumps) create review & merge overhead with no security value. This turns those off while **keeping Dependabot security updates**, which run on a separate internal limit and are enabled for this repo (`automated-security-fixes: enabled`).

## Effect
- **npm / gradle / swift / github-actions** — version-update PRs off; **security-update PRs still open automatically**.
- **docker / helm** (where present) — left **unchanged**: they keep receiving version-update PRs (Dependabot has no security updates for these ecosystems, so disabling them would stop updates entirely).

Fleet-wide change mirroring egym/mwa-bma-features#1995.
